### PR TITLE
Harden webhook setup and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ CHANNEL_USERNAME=@your_channel_username
 # לדוגמה: @my_news_channel
 # חשוב: הבוט חייב להיות admin בערוץ!
 
+# Webhook (Render / Production)
+# WEBHOOK_URL=https://your-app.onrender.com
+# WEBHOOK_PATH=webhook
+
 # MongoDB Atlas (Optional - for future features)
 # MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/refiner_bot?retryWrites=true&w=majority
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -87,10 +87,11 @@ TELEGRAM_BOT_TOKEN = <הטוקן שלך>
 GEMINI_API_KEY = <המפתח שלך>
 CHANNEL_USERNAME = @your_channel
 WEBHOOK_URL = https://refiner-bot.onrender.com
+WEBHOOK_PATH = webhook  # אופציונלי (אם ריק, משתמש בטוקן)
 PORT = 10000
 ```
 
-⚠️ **חשוב:** `WEBHOOK_URL` צריך להיות ה-URL של השרת ב-Render!
+⚠️ **חשוב:** `WEBHOOK_URL` צריך להיות ה-URL של השרת ב-Render (ללא / בסוף)
 
 ### שלב 6: Deploy!
 

--- a/README.md
+++ b/README.md
@@ -192,12 +192,12 @@ services:
 
 ### אפשרות 2: Webhooks (מומלץ לפרודקשן)
 
-נדרש Flask/FastAPI wrapper - יצירת endpoint כמו:
+קיימת גרסת Webhook מובנית (`bot_webhook.py`).
+ה-URL יהיה:
 ```
-https://your-app.onrender.com/webhook
+https://your-app.onrender.com/<WEBHOOK_PATH>
 ```
-
-אספר אם רוצה שאכתוב גרסת Webhook!
+ברירת מחדל: `WEBHOOK_PATH` הוא הטוקן של הבוט (ניתן לשנות ל-`webhook`).
 
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -16,6 +16,8 @@ services:
         sync: false
       - key: WEBHOOK_URL
         sync: false
+      - key: WEBHOOK_PATH
+        sync: false
       - key: PYTHON_VERSION
         value: "3.11.0"
       - key: LOG_LEVEL


### PR DESCRIPTION
 ה‑setWebhook הצליח, אבל היו WORKER TIMEOUT בגלל /webhook_info. תיקנתי את זה והקשחתי את ה‑webhook כך שלא יחסום, וגם הוספתי WEBHOOK_PATH אופציונלי (כדי להימנע מבעיה אפשרית עם : בטוקן ב‑URL).

✅ דחפתי תיקון חדש — צריך רק Redeploy.

מה לעשות עכשיו (בקצרה)
Redeploy מה‑GitHub ב‑Render.
ב‑Environment Variables:
WEBHOOK_URL=https://refiner-bot.onrender.com (בלי / בסוף)
מומלץ: WEBHOOK_PATH=webhook
אחרי עלייה:
פתח בדפדפן
https://refiner-bot.onrender.com/set_webhook
עכשיו נסה /start בצ’אט פרטי עם הבוט.
אם עדיין לא מגיב
פתח:

https://api.telegram.org/bot<TOKEN>/getWebhookInfo
ושלח לי את הפלט (אפשר בלי הטוקן עצמו).

אגב: הטוקן שלך הופיע בלוגים ששלחת. מומלץ להחליף אותו ב‑@BotFather אחרי שנפתור, ליתר ביטחון.

רוצה שאבדוק איתך את getWebhookInfo?


