### PR TITLE
Fix truncated responses - increase max_output_tokens

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")  # ברירת מח�
 GEMINI_TEMPERATURE = float(os.getenv("GEMINI_TEMPERATURE", "0.7"))
 GEMINI_TOP_P = float(os.getenv("GEMINI_TOP_P", "0.9"))
 GEMINI_TOP_K = int(os.getenv("GEMINI_TOP_K", "40"))
-GEMINI_MAX_TOKENS = int(os.getenv("GEMINI_MAX_TOKENS", "2048"))
+GEMINI_MAX_TOKENS = int(os.getenv("GEMINI_MAX_TOKENS", "8192"))  # הוגדל לתמיכה בטקסטים ארוכים
 
 # ======================
 # MongoDB Configuration (Optional)


### PR DESCRIPTION
- Increased max_output_tokens from 2048 to 8192 to support longer texts
- Added detection for truncated responses with warning message
- Updated config.py default value accordingly

Hebrew text requires more tokens, so 2048 was not enough for longer posts.