### PR TITLE
Improve GPT fallback logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -449,8 +449,12 @@ async def refine_text_with_gemini(original_text: str) -> str:
         logger.error(f"❌ Gemini API error: {gemini_error}")
 
         if not OPENAI_API_KEY:
+            logger.warning(
+                "⚠️ GPT fallback skipped - OPENAI_API_KEY is not set in environment."
+            )
             raise
 
+        logger.warning("🔁 Gemini failed - attempting GPT fallback...")
         try:
             return await refine_text_with_gpt(original_text)
         except Exception as gpt_error:
@@ -879,6 +883,10 @@ def main():
         raise ValueError("❌ GEMINI_API_KEY not set in environment!")
     
     logger.info("🤖 Starting Refiner Bot...")
+    if OPENAI_API_KEY:
+        logger.info(f"✅ GPT fallback is ENABLED (model: {OPENAI_MODEL})")
+    else:
+        logger.info("ℹ️ GPT fallback is DISABLED (OPENAI_API_KEY not set)")
     
     # יצירת Application
     app = Application.builder().token(TELEGRAM_BOT_TOKEN).build()


### PR DESCRIPTION
- Warn explicitly when GPT fallback is skipped because OPENAI_API_KEY is missing
- Log a message before attempting the fallback call so it's visible in production logs
- Log at startup whether GPT fallback is enabled or disabled
הוספתי לוגים מפורטים. **הסיבה הכי סבירה שלא עבד: `OPENAI_API_KEY` לא מוגדר במשתני הסביבה ב-Render.**

**מה לבדוק:**
1. ב-Render → Service → Environment - צריך להוסיף `OPENAI_API_KEY` עם המפתח שלך מ-OpenAI.
2. אחרי הפריסה הבאה, בלוג ה-startup אמור להופיע:
   - `✅ GPT fallback is ENABLED (model: gpt-4o-mini)` - מצוין, מוגדר.
   - `ℹ️ GPT fallback is DISABLED (OPENAI_API_KEY not set)` - חסר המפתח.
3. אם שוב יש שגיאת Gemini, עכשיו תראה אחד משניים:
   - `🔁 Gemini failed - attempting GPT fallback...` → מנסה.
   - `⚠️ GPT fallback skipped - OPENAI_API_KEY is not set in environment.` → עדיין חסר.

שים לב: צריך גם שהפריסה ב-Render תכלול את התלות החדשה `openai==1.55.0` (תצא אוטומטית מ-requirements.txt).