### PR TITLE
Fix OpenAI client init failure ('proxies' kwarg) by bumping SDK

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -367,7 +367,11 @@ async def refine_text_with_gpt(original_text: str) -> str:
     """
     client = _get_openai_client()
     if client is None:
-        raise RuntimeError("OpenAI fallback is not configured (OPENAI_API_KEY missing).")
+        if not OPENAI_API_KEY:
+            raise RuntimeError("OpenAI fallback is not configured (OPENAI_API_KEY missing).")
+        raise RuntimeError(
+            "OpenAI fallback client failed to initialize - see previous log for details."
+        )
 
     logger.info(
         f"🔁 Using GPT fallback ({OPENAI_MODEL}) for text of length: {len(original_text)}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-telegram-bot==22.6
 google-genai==1.60.0
 
 # OpenAI SDK - used as a fallback when Gemini is unavailable
-openai==1.55.0
+openai==1.58.1
 
 # MongoDB Driver (optional - for future features)
 pymongo==4.16.0


### PR DESCRIPTION
openai==1.55.0 crashes on init with httpx >= 0.28 due to the 'proxies' keyword being removed. Upgrade to openai==1.58.1 which no longer passes that kwarg.

Also make the fallback error message honest: distinguish between 'API key missing' and 'client init failed' instead of always claiming the key is missing.

מצאנו ותיקנו! זו לא הייתה בעיית API key - ה-API key עבד מצוין, פשוט ה-client של openai נפל ב-init בגלל באג ישן בחבילה:

```
Client.__init__() got an unexpected keyword argument 'proxies'
```

זה קורה בגרסה `openai==1.55.0` כשמותקן `httpx>=0.28` לצדה. שדרגתי ל-`openai==1.58.1` שבו הבאג מתוקן. אחרי הפריסה הבאה ב-Render ה-fallback אמור לעבוד.